### PR TITLE
🧩 Retake JSDoc for `BaseGraphqlLauncher.createCapsule()` to kick out `CapsuleParams`

### DIFF
--- a/lib/client/graphql/BaseGraphqlLauncher.js
+++ b/lib/client/graphql/BaseGraphqlLauncher.js
@@ -183,7 +183,7 @@ export default class BaseGraphqlLauncher {
    * Create instance of capsule with result.
    *
    * @template C
-   * @param {CapsuleParams} params - Parameters.
+   * @param {furo.BaseGraphqlCapsuleFactoryParams<*>} params - Parameters.
    * @returns {InstanceType<C>} Instance of capsule.
    */
   static createCapsule ({

--- a/lib/client/graphql/BaseGraphqlLauncher.js
+++ b/lib/client/graphql/BaseGraphqlLauncher.js
@@ -572,15 +572,6 @@ export default class BaseGraphqlLauncher {
 
 /**
  * @typedef {{
- *   rawResponse: Response | null
- *   payload: furo.Payload<*> | null
- *   result: object | null
- *   abortedReason?: import('./BaseGraphqlCapsule.js').LAUNCH_ABORTED_REASON
- * }} CapsuleParams
- */
-
-/**
- * @typedef {{
  *   payload: furo.Payload<*>
  *   hooks?: GraphqlLauncherHooks
  * }} GraphqlLaunchRequestArgs

--- a/types/graphql.d.ts
+++ b/types/graphql.d.ts
@@ -1,0 +1,65 @@
+import type {
+  PayloadCtor,
+  Payload,
+  BaseGraphqlPayloadParams as PayloadParams,
+  BaseGraphqlPayloadFactoryParams as PayloadFactoryParams,
+  GraphqlRequestVariables as RequestVariables,
+} from '../lib/client/graphql/BaseGraphqlPayload'
+
+import type {
+  CapsuleCtor,
+  Capsule,
+  BaseGraphqlCapsuleParams as CapsuleParams,
+  BaseGraphqlCapsuleFactoryParams as CapsuleFactoryParams,
+  GraphqlResponse as Response,
+  GraphqlResponseContent as ResponseContent,
+  GraphqlResponseError as ResponseError,
+  LAUNCH_ABORTED_REASON,
+} from '../lib/client/graphql/BaseGraphqlCapsule'
+
+import type {
+  LauncherCtor,
+  Launcher,
+  BaseGraphqlLauncherParams as LauncherParams,
+  BaseGraphqlLauncherFactoryParams as LauncherFactoryParams,
+  GraphqlLaunchRequestArgs as LaunchRequestArgs,
+  GraphqlLauncherHooks as LauncherHooks,
+  GraphqlRequestArgs as RequestArgs,
+} from '../lib/client/graphql/BaseGraphqlLauncher'
+
+/**
+ * Furo GraphQL types
+ */
+declare global {
+  namespace GraphqlType {
+    export {
+      // Payload
+      PayloadCtor,
+      Payload,
+      PayloadParams,
+      PayloadFactoryParams,
+      RequestVariables,
+
+      // Capsule
+      CapsuleCtor,
+      Capsule,
+      CapsuleParams,
+      CapsuleFactoryParams,
+
+      Response,
+      ResponseContent,
+      ResponseError,
+      LAUNCH_ABORTED_REASON,
+
+      // Launcher
+      LauncherCtor,
+      Launcher,
+      LauncherParams,
+      LauncherFactoryParams,
+
+      LaunchRequestArgs,
+      LauncherHooks,
+      RequestArgs,
+    }
+  }
+}


### PR DESCRIPTION
# Why

* Close #59