### PR TITLE
🧩 Retake JSDoc for `BaseGraphqlLauncher.createCapsule()` to kick out `CapsuleParams` type

### DIFF
--- a/lib/client/graphql/BaseGraphqlLauncher.js
+++ b/lib/client/graphql/BaseGraphqlLauncher.js
@@ -183,7 +183,7 @@ export default class BaseGraphqlLauncher {
    * Create instance of capsule with result.
    *
    * @template C
-   * @param {CapsuleParams} params - Parameters.
+   * @param {furo.BaseGraphqlCapsuleFactoryParams<*>} params - Parameters.
    * @returns {InstanceType<C>} Instance of capsule.
    */
   static createCapsule ({

--- a/lib/client/graphql/BaseGraphqlLauncher.js
+++ b/lib/client/graphql/BaseGraphqlLauncher.js
@@ -572,15 +572,6 @@ export default class BaseGraphqlLauncher {
 
 /**
  * @typedef {{
- *   rawResponse: Response | null
- *   payload: furo.Payload<*> | null
- *   result: object | null
- *   abortedReason?: import('./BaseGraphqlCapsule.js').LAUNCH_ABORTED_REASON
- * }} CapsuleParams
- */
-
-/**
- * @typedef {{
  *   payload: furo.Payload<*>
  *   hooks?: GraphqlLauncherHooks
  * }} GraphqlLaunchRequestArgs


### PR DESCRIPTION
# Why

* Close #59
