### PR TITLE
🧩 Retake JSDoc for `BaseGraphqlSubscriber.createCapsule()` to kick out `CapsuleParams`

### DIFF
--- a/lib/client/graphql/BaseGraphqlSubscriber.js
+++ b/lib/client/graphql/BaseGraphqlSubscriber.js
@@ -136,7 +136,7 @@ export default class BaseGraphqlSubscriber {
    * Create instance of capsule with result.
    *
    * @template C
-   * @param {CapsuleParams} params - Parameters.
+   * @param {furo.BaseSubscriptionGraphqlCapsuleFactoryParams<*>} params - Parameters.
    * @returns {InstanceType<C>} Instance of capsule.
    */
   static createCapsule ({

--- a/lib/client/graphql/BaseGraphqlSubscriber.js
+++ b/lib/client/graphql/BaseGraphqlSubscriber.js
@@ -444,14 +444,6 @@ export default class BaseGraphqlSubscriber {
 
 /**
  * @typedef {{
- *   payload: furo.SubscriptionPayload<*> | null
- *   result: object | null
- *   abortedReason?: import('./BaseSubscriptionGraphqlCapsule').SUBSCRIBE_ABORTED_REASON
- * }} CapsuleParams
- */
-
-/**
- * @typedef {{
  *   onPublish: (capsule: C) => void
  *   onDisconnected?: (args: {
  *     payload: P


### PR DESCRIPTION
# Why

* Close #61