### PR TITLE
🧩 Kick out duplicated `GraphqlRequestArgs` type from `furo` namespace

### DIFF
--- a/types/furo.d.ts
+++ b/types/furo.d.ts
@@ -187,7 +187,6 @@ declare global {
       BaseGraphqlSubscriberFactoryParams,
 
       GraphqlSubscribeRequestArgs,
-      GraphqlRequestArgs,
       GraphqlSubscriberHooks,
 
       // from SubscriptionConnector


### PR DESCRIPTION
# Why

* Close #67