### PR TITLE
🧩 Change return value type of `BaseRestfulApiLuncher#get:baseUrl` to `string`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -274,7 +274,7 @@ export default class BaseRestfulApiLauncher {
   /**
    * get: Base URL.
    *
-   * @returns {RequestInfo | URL} Endpoint URL.
+   * @returns {string} Endpoint URL.
    */
   get baseUrl () {
     return this.config.BASE_URL


### PR DESCRIPTION
# Why

* Close #114