### PR TITLE
🦵 Kick out `BaseRestfulApiPayload.resolveBaseUrl()`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiPayload.js
+++ b/lib/client/restfulapi/BaseRestfulApiPayload.js
@@ -328,28 +328,6 @@ export default class BaseRestfulApiPayload {
   }
 
   /**
-   * Resolve base URL from base URL.
-   *
-   * @param {{
-   *   baseUrl: RestfulApiType.RequestUrl
-   * }} params - Parameters.
-   * @returns {string} Resolved URL as string.
-   */
-  static resolveBaseUrl ({
-    baseUrl,
-  }) {
-    if (baseUrl instanceof URL) {
-      return baseUrl.origin
-    }
-
-    if (baseUrl instanceof Request) {
-      return new URL(baseUrl.url).origin
-    }
-
-    return baseUrl
-  }
-
-  /**
    * Is body required method.
    *
    * @returns {boolean} true: body is required, false: body is not required.

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiPayload.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiPayload.js
@@ -1406,38 +1406,6 @@ describe('BaseRestfulApiPayload', () => {
 })
 
 describe('BaseRestfulApiPayload', () => {
-  describe('.resolveBaseUrl()', () => {
-    const cases = [
-      {
-        args: {
-          baseUrl: 'https://alpha.example.com',
-        },
-        expected: 'https://alpha.example.com',
-      },
-      {
-        args: {
-          baseUrl: new URL('https://beta.example.com'),
-        },
-        expected: 'https://beta.example.com',
-      },
-      {
-        args: {
-          baseUrl: new Request('https://gamma.example.com'),
-        },
-        expected: 'https://gamma.example.com',
-      },
-    ]
-
-    test.each(cases)('baseUrl: $args.baseUrl', ({ args, expected }) => {
-      const actual = BaseRestfulApiPayload.resolveBaseUrl(args)
-
-      expect(actual)
-        .toEqual(expected)
-    })
-  })
-})
-
-describe('BaseRestfulApiPayload', () => {
   describe('.isBodyRequiredMethod()', () => {
     describe('to be truthy', () => {
       const cases = [


### PR DESCRIPTION
# Why

* Close #118