### PR TITLE
💪 Retake `BaseRestfulApiPayload#buildPathname()` with `PathnameBuilder`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiPayload.js
+++ b/lib/client/restfulapi/BaseRestfulApiPayload.js
@@ -3,6 +3,7 @@ import {
 } from './constants.js'
 
 import RestMethodRestfulApiPayloadDerivedCtorRegistry from '../../tools/derived-ctor-registry/concretes/RestMethodRestfulApiPayloadDerivedCtorRegistry.js'
+import PathnameBuilder from '~/lib/tools/PathnameBuilder.js'
 
 /**
  * Base class of GraphQL payload.
@@ -442,13 +443,13 @@ export default class BaseRestfulApiPayload {
    * @returns {string} Pathname.
    */
   buildPathname () {
-    // Replace path parameters in pathname
-    return `${this.Ctor.prefixPathname}${this.Ctor.pathname}`
-      .replace(
-        /(?<=\/):(\w+)/ug,
-        (_, key) =>
-          this.pathParameterHash[key] ?? ''
-      )
+    const builder = PathnameBuilder.create({
+      templatePathname: `${this.Ctor.prefixPathname}${this.Ctor.pathname}`,
+    })
+
+    return builder.buildPathname({
+      valueHash: this.pathParameterHash,
+    })
   }
 
   /**

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiPayload.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiPayload.js
@@ -1941,7 +1941,7 @@ describe('BaseRestfulApiPayload', () => {
       const cases = [
         {
           args: {
-            pathname: '/alpha-endpoint/:id',
+            pathname: '/alpha-endpoint/[id]',
             prefixPathname: '/v1',
             pathParameterHash: {
               id: 10001,
@@ -1951,7 +1951,7 @@ describe('BaseRestfulApiPayload', () => {
         },
         {
           args: {
-            pathname: '/beta-endpoint/:id/:name',
+            pathname: '/beta-endpoint/[id]/[name]',
             prefixPathname: '/v2',
             pathParameterHash: {
               id: 20002,
@@ -1986,7 +1986,7 @@ describe('BaseRestfulApiPayload', () => {
       const cases = [
         {
           args: {
-            pathname: '/alpha-endpoint/:id',
+            pathname: '/alpha-endpoint/[id]',
             prefixPathname: '/v1',
             query: {
               alpha: 111,
@@ -2000,7 +2000,7 @@ describe('BaseRestfulApiPayload', () => {
         },
         {
           args: {
-            pathname: '/beta-endpoint/:id/:name',
+            pathname: '/beta-endpoint/[id]/[name]',
             prefixPathname: '/v2',
             query: {
               gamma: 333,

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiPayload.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiPayload.js
@@ -2050,7 +2050,7 @@ describe('BaseRestfulApiPayload', () => {
       },
       {
         args: {
-          pathname: '/beta-endpoint/:id/:name',
+          pathname: '/beta-endpoint/[id]/[name]',
           prefixPathname: '/v2',
           pathParameterHash: {
             id: 10002,
@@ -2061,7 +2061,7 @@ describe('BaseRestfulApiPayload', () => {
       },
       {
         args: {
-          pathname: '/gamma-endpoint/:documentId/edit',
+          pathname: '/gamma-endpoint/[documentId]/edit',
           prefixPathname: '/v3',
           pathParameterHash: {
             documentId: 20003,


### PR DESCRIPTION
# Why

* Close #152
