### PR TITLE
🧹 Rename `BaseRestfulApiCapsule.get:jsonParseErrorCode` to `.get:responseBodyParseErrorCode`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -191,11 +191,11 @@ export default class BaseRestfulApiCapsule {
   }
 
   /**
-   * get: error code for JSON parse error.
+   * get: error code for response body parse error.
    *
    * @returns {string} Error code.
    */
-  static get jsonParseErrorCode () {
+  static get responseBodyParseErrorCode () {
     return '192.X000.002'
   }
 
@@ -343,7 +343,7 @@ export default class BaseRestfulApiCapsule {
     }
 
     if (this.hasJsonParseError()) {
-      return this.Ctor.jsonParseErrorCode
+      return this.Ctor.responseBodyParseErrorCode
     }
 
     if (this.hasStatusCodeError()) {

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -637,11 +637,11 @@ describe('BaseRestfulApiCapsule', () => {
 })
 
 describe('BaseRestfulApiCapsule', () => {
-  describe('.get:jsonParseErrorCode', () => {
+  describe('.get:responseBodyParseErrorCode', () => {
     test('to be fixed value', () => {
       const expected = '192.X000.002'
 
-      const actual = BaseRestfulApiCapsule.jsonParseErrorCode
+      const actual = BaseRestfulApiCapsule.responseBodyParseErrorCode
 
       expect(actual)
         .toBe(expected)


### PR DESCRIPTION
# Why

* Close #192
