### PR TITLE
🧹 Rename `BaseRestfulApiCapsule.createAsJsonParseError()` to `.createAsResponseBodyParseError()`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -141,7 +141,7 @@ export default class BaseRestfulApiCapsule {
   }
 
   /**
-   * Factory method to create as JSON parse error.
+   * Factory method to create as response body parse error.
    *
    * @template {RestfulApiType.Payload<*, *, *>} P
    * @template {CapsuleCtor<R>} C, R
@@ -152,7 +152,7 @@ export default class BaseRestfulApiCapsule {
    * @returns {InstanceType<C>} Instance of this class.
    * @this {C}
    */
-  static createAsJsonParseError ({
+  static createAsResponseBodyParseError ({
     rawResponse,
     payload,
   }) {

--- a/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -265,7 +265,7 @@ export default class BaseRestfulApiLauncher {
     rawResponse,
     payload,
   }) {
-    return this.Capsule.createAsJsonParseError({
+    return this.Capsule.createAsResponseBodyParseError({
       rawResponse,
       payload,
     })

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -545,7 +545,7 @@ describe('BaseRestfulApiCapsule', () => {
 })
 
 describe('BaseRestfulApiCapsule', () => {
-  describe('.createAsJsonParseError()', () => {
+  describe('.createAsResponseBodyParseError()', () => {
     const cases = [
       {
         input: {
@@ -571,7 +571,7 @@ describe('BaseRestfulApiCapsule', () => {
 
     describe('to be instance of own class', () => {
       test.each(cases)('payload: $input.payload', ({ input }) => {
-        const actual = BaseRestfulApiCapsule.createAsJsonParseError(input)
+        const actual = BaseRestfulApiCapsule.createAsResponseBodyParseError(input)
 
         expect(actual)
           .toBeInstanceOf(BaseRestfulApiCapsule)
@@ -588,7 +588,7 @@ describe('BaseRestfulApiCapsule', () => {
 
         const createSpy = jest.spyOn(BaseRestfulApiCapsule, 'create')
 
-        BaseRestfulApiCapsule.createAsJsonParseError(input)
+        BaseRestfulApiCapsule.createAsResponseBodyParseError(input)
 
         expect(createSpy)
           .toHaveBeenCalledWith(expected)

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -2585,7 +2585,7 @@ describe('BaseRestfulApiLauncher', () => {
           }
         }}`) // ERROR: last } is doubled
 
-        const capsuleTally = BaseRestfulApiCapsule.createAsJsonParseError({
+        const capsuleTally = BaseRestfulApiCapsule.createAsResponseBodyParseError({
           rawResponse: rawResponseTally,
           payload: input.payload,
         })


### PR DESCRIPTION
# Why

* Close #194
