### PR TITLE
🧹 Rename `BaseRestfulApiCapsule#hasJsonParseError()` to `#hasResponseBodyParseError()`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -255,7 +255,7 @@ export default class BaseRestfulApiCapsule {
   hasError () {
     return this.hasInvalidParameterHashError()
       || this.hasNetworkError()
-      || this.hasJsonParseError()
+      || this.hasResponseBodyParseError()
       || this.hasStatusCodeError()
       || this.hasResultError()
   }
@@ -292,11 +292,11 @@ export default class BaseRestfulApiCapsule {
   }
 
   /**
-   * Check to have JSON parse error.
+   * Check to have response body parse error.
    *
    * @returns {BooleanLike} true: has JSON parse error.
    */
-  hasJsonParseError () {
+  hasResponseBodyParseError () {
     return this.rawResponse
       && !this.result
   }
@@ -342,7 +342,7 @@ export default class BaseRestfulApiCapsule {
       return this.Ctor.networkErrorCode
     }
 
-    if (this.hasJsonParseError()) {
+    if (this.hasResponseBodyParseError()) {
       return this.Ctor.responseBodyParseErrorCode
     }
 

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -1477,7 +1477,7 @@ describe('BaseRestfulApiCapsule', () => {
 })
 
 describe('BaseRestfulApiCapsule', () => {
-  describe('#hasJsonParseError()', () => {
+  describe('#hasResponseBodyParseError()', () => {
     const mockResponse = new Response()
     const mockPayload = BaseRestfulApiPayload.create()
 
@@ -1500,7 +1500,7 @@ describe('BaseRestfulApiCapsule', () => {
           }
           const capsule = new BaseRestfulApiCapsule(args)
 
-          const actual = capsule.hasJsonParseError()
+          const actual = capsule.hasResponseBodyParseError()
 
           expect(actual)
             .toBeTruthy()
@@ -1540,7 +1540,7 @@ describe('BaseRestfulApiCapsule', () => {
           }
           const capsule = new BaseRestfulApiCapsule(args)
 
-          const actual = capsule.hasJsonParseError()
+          const actual = capsule.hasResponseBodyParseError()
 
           expect(actual)
             .toBeFalsy()
@@ -1587,7 +1587,7 @@ describe('BaseRestfulApiCapsule', () => {
           }
           const capsule = new BaseRestfulApiCapsule(args)
 
-          const actual = capsule.hasJsonParseError()
+          const actual = capsule.hasResponseBodyParseError()
 
           expect(actual)
             .toBeFalsy()

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -874,7 +874,7 @@ describe('BaseRestfulApiCapsule', () => {
           input: {
             hasInvalidParameterHashError: true,
             // hasNetworkError: true,
-            // hasJsonParseError: true,
+            // hasResponseBodyParseError: true,
             // hasStatusCodeError: true,
             // hasResultError: true,
           },
@@ -883,7 +883,7 @@ describe('BaseRestfulApiCapsule', () => {
           input: {
             // hasInvalidParameterHashError: true,
             hasNetworkError: true,
-            // hasJsonParseError: true,
+            // hasResponseBodyParseError: true,
             // hasStatusCodeError: true,
             // hasResultError: true,
           },
@@ -892,7 +892,7 @@ describe('BaseRestfulApiCapsule', () => {
           input: {
             // hasInvalidParameterHashError: true,
             // hasNetworkError: true,
-            hasJsonParseError: true,
+            hasResponseBodyParseError: true,
             // hasStatusCodeError: true,
             // hasResultError: true,
           },
@@ -901,7 +901,7 @@ describe('BaseRestfulApiCapsule', () => {
           input: {
             // hasInvalidParameterHashError: true,
             // hasNetworkError: true,
-            // hasJsonParseError: true,
+            // hasResponseBodyParseError: true,
             hasStatusCodeError: true,
             // hasResultError: true,
           },
@@ -910,7 +910,7 @@ describe('BaseRestfulApiCapsule', () => {
           input: {
             // hasInvalidParameterHashError: true,
             // hasNetworkError: true,
-            // hasJsonParseError: true,
+            // hasResponseBodyParseError: true,
             // hasStatusCodeError: true,
             hasResultError: true,
           },
@@ -930,8 +930,8 @@ describe('BaseRestfulApiCapsule', () => {
           .mockReturnValue(input.hasInvalidParameterHashError)
         jest.spyOn(capsule, 'hasNetworkError')
           .mockReturnValue(input.hasNetworkError)
-        jest.spyOn(capsule, 'hasJsonParseError')
-          .mockReturnValue(input.hasJsonParseError)
+        jest.spyOn(capsule, 'hasResponseBodyParseError')
+          .mockReturnValue(input.hasResponseBodyParseError)
         jest.spyOn(capsule, 'hasStatusCodeError')
           .mockReturnValue(input.hasStatusCodeError)
         jest.spyOn(capsule, 'hasResultError')
@@ -950,7 +950,7 @@ describe('BaseRestfulApiCapsule', () => {
           input: {
             hasInvalidParameterHashError: false,
             hasNetworkError: false,
-            hasJsonParseError: false,
+            hasResponseBodyParseError: false,
             hasStatusCodeError: false,
             hasResultError: false,
           },
@@ -971,8 +971,8 @@ describe('BaseRestfulApiCapsule', () => {
           .mockReturnValue(input.hasInvalidParameterHashError)
         jest.spyOn(capsule, 'hasNetworkError')
           .mockReturnValue(input.hasNetworkError)
-        jest.spyOn(capsule, 'hasJsonParseError')
-          .mockReturnValue(input.hasJsonParseError)
+        jest.spyOn(capsule, 'hasResponseBodyParseError')
+          .mockReturnValue(input.hasResponseBodyParseError)
         jest.spyOn(capsule, 'hasStatusCodeError')
           .mockReturnValue(input.hasStatusCodeError)
         jest.spyOn(capsule, 'hasResultError')


### PR DESCRIPTION
# Why

* Close #195