### PR TITLE
🧹 Rename `BaseRestfulApiLauncher.createCapsuleAsJsonParseError()` to `.createCapsuleAsResponseBodyParseError()`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -253,7 +253,7 @@ export default class BaseRestfulApiLauncher {
   }
 
   /**
-   * Create instance of capsule with result as JSON parse error.
+   * Create instance of capsule with result as response body parse error.
    *
    * @param {{
    *   rawResponse: Response
@@ -261,7 +261,7 @@ export default class BaseRestfulApiLauncher {
    * }} params - Parameters.
    * @returns {RestfulApiType.Capsule<*, *>} Instance of capsule.capsule.
    */
-  static createCapsuleAsJsonParseError ({
+  static createCapsuleAsResponseBodyParseError ({
     rawResponse,
     payload,
   }) {
@@ -519,7 +519,7 @@ export default class BaseRestfulApiLauncher {
       response,
     })
     if (result === null) {
-      return this.Ctor.createCapsuleAsJsonParseError({
+      return this.Ctor.createCapsuleAsResponseBodyParseError({
         rawResponse: response,
         payload,
       })

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -975,7 +975,7 @@ describe('BaseRestfulApiLauncher', () => {
 })
 
 describe('BaseRestfulApiLauncher', () => {
-  describe('.createCapsuleAsJsonParseError()', () => {
+  describe('.createCapsuleAsResponseBodyParseError()', () => {
     const capsuleCases = [
       {
         input: {
@@ -1028,7 +1028,7 @@ describe('BaseRestfulApiLauncher', () => {
         }
 
         test.each(cases)('payload: $args.payload', ({ args }) => {
-          const capsule = Launcher.createCapsuleAsJsonParseError(args)
+          const capsule = Launcher.createCapsuleAsResponseBodyParseError(args)
 
           expect(capsule)
             .toBeInstanceOf(input.Capsule)
@@ -1054,7 +1054,7 @@ describe('BaseRestfulApiLauncher', () => {
 
           const createSpy = jest.spyOn(input.Capsule, 'create')
 
-          Launcher.createCapsuleAsJsonParseError(args)
+          Launcher.createCapsuleAsResponseBodyParseError(args)
 
           expect(createSpy)
             .toHaveBeenCalledWith(expected)

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -2595,7 +2595,7 @@ describe('BaseRestfulApiLauncher', () => {
           payload: input.payload,
         }
 
-        const createCapsuleAsJsonParseErrorSpy = jest.spyOn(BaseRestfulApiLauncher, 'createCapsuleAsJsonParseError')
+        const createCapsuleAsResponseBodyParseErrorSpy = jest.spyOn(BaseRestfulApiLauncher, 'createCapsuleAsResponseBodyParseError')
           .mockReturnValue(capsuleTally)
 
         const launcher = BaseRestfulApiLauncher.create({
@@ -2614,7 +2614,7 @@ describe('BaseRestfulApiLauncher', () => {
         expect(actual)
           .toEqual(capsuleTally)
 
-        expect(createCapsuleAsJsonParseErrorSpy)
+        expect(createCapsuleAsResponseBodyParseErrorSpy)
           .toHaveBeenCalledWith(expectedArgs)
       })
     })


### PR DESCRIPTION
# Why

* Close #198