### PR TITLE
Define `#get:content` for BaseSubscriptionGraphqlCapsule

### DIFF
--- a/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
+++ b/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
@@ -168,6 +168,16 @@ export default class BaseSubscriptionGraphqlCapsule {
   }
 
   /**
+   * get: Content as result.data
+   *
+   * @returns {D | null} Content.
+   */
+  get content () {
+    return /** @type {D} */ (this.result?.data)
+      ?? null
+  }
+
+  /**
    * Check to have content.
    *
    * @returns {BooleanLike} true: has content.


### PR DESCRIPTION
# Why

* Close #237
* Close https://chiho-internal.openreach.tech/tasks/4425

# How

* Define `#get:content` for `BaseSubscriptionGraphqlCapsule`.
