### PR TITLE
Define `#get:errors` for BaseSubscriptionGraphqlCapsule

### DIFF
--- a/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
+++ b/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
@@ -178,6 +178,16 @@ export default class BaseSubscriptionGraphqlCapsule {
   }
 
   /**
+   * get: Errors as result.errors
+   *
+   * @returns {Array<GraphqlType.ResponseError>} Errors.
+   */
+  get errors () {
+    return this.result?.errors
+      ?? []
+  }
+
+  /**
    * Check to have content.
    *
    * @returns {BooleanLike} true: has content.


### PR DESCRIPTION
# Why

* Close #238
* Close https://chiho-internal.openreach.tech/tasks/4427

# How

* Define `#get:errors` for BaseSubscriptionGraphqlCapsule.
