### PR TITLE
Enhance `BaseSubscriptionGraphqlCapsule` with getters for `content` and `errors`

### DIFF
--- a/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
+++ b/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
@@ -168,6 +168,16 @@ export default class BaseSubscriptionGraphqlCapsule {
   }
 
   /**
+   * get: Content as result.data
+   *
+   * @returns {D | null} Content.
+   */
+  get content () {
+    return /** @type {D} */ (this.result?.data)
+      ?? null
+  }
+
+  /**
    * Check to have content.
    *
    * @returns {BooleanLike} true: has content.

--- a/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
+++ b/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
@@ -243,9 +243,14 @@ export default class BaseSubscriptionGraphqlCapsule {
    * @returns {BooleanLike} true: has query error.
    */
   hasQueryError () {
-    return this.result
-      ?.errors
-      ?? false
+    /*
+     * NOTE: Cannot use `this.errors` here.
+     * Because `this.result.errors` returns [] via parsed result, it is not the correct approach.
+     * `this.errors` always returns an Array, thus we cannot confirm whether `this.result.errors` exists or not.
+     */
+    return Boolean(
+      this.result?.errors
+    )
   }
 
   /**
@@ -282,9 +287,7 @@ export default class BaseSubscriptionGraphqlCapsule {
    * @returns {Array<GraphqlType.ResponseError>} Array of errors.
    */
   extractErrors () {
-    return this.result
-      ?.errors
-      ?? []
+    return this.errors
   }
 
   /**

--- a/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
+++ b/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
@@ -190,12 +190,10 @@ export default class BaseSubscriptionGraphqlCapsule {
   /**
    * Check to have content.
    *
-   * @returns {BooleanLike} true: has content.
+   * @returns {boolean} true: has content.
    */
   hasContent () {
-    return this.result
-      ?.data
-      ?? false
+    return Boolean(this.content)
   }
 
   /**
@@ -299,10 +297,7 @@ export default class BaseSubscriptionGraphqlCapsule {
       return null
     }
 
-    return /** @type {*} */ (
-      this.result?.data
-      ?? null
-    )
+    return /** @type {*} */ (this.content)
   }
 }
 

--- a/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
+++ b/lib/client/graphql/BaseSubscriptionGraphqlCapsule.js
@@ -178,6 +178,16 @@ export default class BaseSubscriptionGraphqlCapsule {
   }
 
   /**
+   * get: Errors as result.errors
+   *
+   * @returns {Array<GraphqlType.ResponseError>} Errors.
+   */
+  get errors () {
+    return this.result?.errors
+      ?? []
+  }
+
+  /**
    * Check to have content.
    *
    * @returns {BooleanLike} true: has content.


### PR DESCRIPTION
# Why

* Close #236
* Close https://chiho-internal.openreach.tech/tasks/4428

# How

* Enhance `BaseSubscriptionGraphqlCapsule` with getters for `content` and `errors`.

> [!note]
> All commits have been reviewed, merge only.
