### PR TITLE
💪 Update `BaseRestfulApiLauncher#extendRequestHooks()` to return fulfilled hooks

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -369,13 +369,13 @@ export default class BaseRestfulApiLauncher {
    * Extend request hooks.
    *
    * @param {RestfulApiLauncherHooks} hooks - Hooks.
-   * @returns {RestfulApiLauncherHooks} Extended hooks.
+   * @returns {Required<RestfulApiLauncherHooks>} Extended hooks.
    */
   extendRequestHooks ({
-    beforeRequest,
-    afterRequest,
-    onUploadProgress,
-    onDownloadProgress,
+    beforeRequest = async () => false,
+    afterRequest = async () => {},
+    onUploadProgress = () => {},
+    onDownloadProgress = () => {},
   }) {
     return {
       beforeRequest: this.extendBeforeRequestHook({

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -1931,177 +1931,276 @@ describe('BaseRestfulApiLauncher', () => {
     })
 
     describe('with partial hooks', () => {
+      const beforeRequestHook = async () => false
+      const afterRequestHook = async () => {}
+      const onUploadProgressHook = () => {}
+      const onDownloadProgressHook = () => {}
+
       const partialCases = [
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              afterRequest: async () => {},
-              onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: afterRequestHook,
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              afterRequest: async () => {},
-              onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: afterRequestHook,
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: afterRequestHook,
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: expect.any(Function),
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              afterRequest: async () => {},
-              onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: afterRequestHook,
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: afterRequestHook,
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: expect.any(Function),
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: expect.any(Function),
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              afterRequest: async () => {},
-              onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: afterRequestHook,
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: afterRequestHook,
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: expect.any(Function),
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: beforeRequestHook,
+            afterRequest: expect.any(Function),
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: afterRequestHook,
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: expect.any(Function),
+            onUploadProgress: onUploadProgressHook,
+            onDownloadProgress: expect.any(Function),
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: expect.any(Function),
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: onDownloadProgressHook,
           },
         },
         {
           input: {
             hooks: {
-              // beforeRequest: async () => false,
-              // afterRequest: async () => {},
-              // onUploadProgress: () => {},
-              // onDownloadProgress: () => {},
+              // beforeRequest: beforeRequestHook,
+              // afterRequest: afterRequestHook,
+              // onUploadProgress: onUploadProgressHook,
+              // onDownloadProgress: onDownloadProgressHook,
             },
+          },
+          expected: {
+            beforeRequest: expect.any(Function),
+            afterRequest: expect.any(Function),
+            onUploadProgress: expect.any(Function),
+            onDownloadProgress: expect.any(Function),
           },
         },
       ]
 
-      test.each(partialCases)('with hooks: $input.hooks', ({ input }) => {
-        const expected = input.hooks
-
+      test.each(partialCases)('with hooks: $input.hooks', ({ input, expected }) => {
         const result = launcher.extendRequestHooks(input.hooks)
 
         // Verify the structure of returned hooks
         expect(result)
-          .toEqual(expected)
+          .toStrictEqual(expected)
       })
     })
   })


### PR DESCRIPTION
# Why

* Close #269
