### PR TITLE
🧩 Fix JSDoc of `BaseRestfulApiLauncher.get:ResponseBodyParser`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -105,7 +105,7 @@ export default class BaseRestfulApiLauncher {
   /**
    * get: Response body parser class.
    *
-   * @returns {typeof import('../../tools/response-body-parser/BaseResponseBodyParser.js').default} Response body parser class.
+   * @returns {typeof import('../../tools/response-body-parser/BaseResponseBodyParser.js').default<*>} Response body parser class.
    */
   static get ResponseBodyParser () {
     return JsonResponseBodyParser


### PR DESCRIPTION
# Why

* Close #271
