### PR TITLE
🧩 Fix JSDoc of `BaseResponseBodyParser`

### DIFF
--- a/lib/tools/response-body-parser/BaseResponseBodyParser.js
+++ b/lib/tools/response-body-parser/BaseResponseBodyParser.js
@@ -1,7 +1,7 @@
 /**
  * Base class for parsing response bodies.
  *
- * @template {Record<string, *>} C - Type of the parsed response body.
+ * @template {Record<string, *>} [C = Record<string, *>] - Type of the parsed response body.
  * @abstract
  */
 export default class BaseResponseBodyParser {


### PR DESCRIPTION
# Why

* Close #273