### PR TITLE
🧩 Tidy up JSDoc in test for `BaseRestfulApiLauncher.createResponseBodyParser()`

### DIFF
--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -1072,7 +1072,7 @@ describe('BaseRestfulApiLauncher', () => {
     /**
      * @type {Array<{
      *   input: {
-     *     Launcher: typeof BaseRestfulApiLauncher,
+     *     Launcher: typeof BaseRestfulApiLauncher
      *   }
      *   expected: typeof BaseResponseBodyParser<*>
      * }>}

--- a/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
+++ b/tests/__tests__/lib/client/restfulapi/BaseRestfulApiLauncher.js
@@ -1074,7 +1074,7 @@ describe('BaseRestfulApiLauncher', () => {
      *   input: {
      *     Launcher: typeof BaseRestfulApiLauncher,
      *   }
-     *   expected: typeof BaseResponseBodyParser,
+     *   expected: typeof BaseResponseBodyParser<*>
      * }>}
      */
     const LauncherCases = [


### PR DESCRIPTION
# Why

* Close #275