### PR TITLE
🧩 Fix type of `Capsule` in `BaseRestfulApiCapsule`

### DIFF
--- a/lib/client/restfulapi/BaseRestfulApiCapsule.js
+++ b/lib/client/restfulapi/BaseRestfulApiCapsule.js
@@ -389,7 +389,7 @@ export default class BaseRestfulApiCapsule {
  */
 
 /**
- * @typedef {InstanceType<CapsuleCtor<RTCConfiguration, P>>} Capsule
+ * @typedef {InstanceType<CapsuleCtor<R, P>>} Capsule
  * @template R - Type of result.
  * @template {RestfulApiType.Payload<*, *, *>} [P = RestfulApiType.Payload<*, *, *>] - Type of payload.
  */


### PR DESCRIPTION
# Why

* Close #287